### PR TITLE
記事追加：サーバー内のメンバー数を取得【discord.py】

### DIFF
--- a/content/blog/3.md
+++ b/content/blog/3.md
@@ -15,6 +15,10 @@ on_message 内で取得する場合。
 ```python
 @client.event
 async def on_message(message)
+    # /test と打った場合のみ反応するように
+    if message.content != '/test':
+        return
+
     # message インスタンスから guild インスタンスを取得
     guild = message.guild 
 
@@ -33,6 +37,6 @@ async def on_message(message)
 
 # ドキュメント
 
-https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.member_count
-https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.members
-[Pythonリスト内包表記の使い方 | note.nkmk.me](https://note.nkmk.me/python-list-comprehension/)
+- [discord.Guild.member_count | discord.py](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.member_count)
+- [discord.Guild.members | discord.py](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.members)
+- [Pythonリスト内包表記の使い方 | note.nkmk.me](https://note.nkmk.me/python-list-comprehension/)

--- a/content/blog/3.md
+++ b/content/blog/3.md
@@ -1,0 +1,38 @@
+---
+author: "1ntegrale9"
+categories: ["discord.py", "Member"]
+date: 2019-12-26T19:13:37+09:00
+title: "サーバー内のメンバー数を取得【discord.py】"
+type: "post"
+draft: false
+
+---
+
+# ソースコード
+
+on_message 内で取得する場合。
+
+```python
+@client.event
+async def on_message(message)
+    # message インスタンスから guild インスタンスを取得
+    guild = message.guild 
+
+    # ユーザとBOTを区別しない場合
+    member_count = guild.member_count
+    await message.channel.send(f'メンバー数：{member_count}')
+
+    # ユーザのみ
+    user_count = sum(1 for member in guild.members if not member.bot)
+    await message.channel.send(f'ユーザ数：{user_count}')
+
+    # BOTのみ
+    bot_count = sum(1 for member in guild.memers if member.bot)
+    await message.channel.send(f'BOT数：{bot_count}')
+```
+
+# ドキュメント
+
+https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.member_count
+https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.members
+[Pythonリスト内包表記の使い方 | note.nkmk.me](https://note.nkmk.me/python-list-comprehension/)


### PR DESCRIPTION
# ソースコード

on_message 内で取得する場合。

```python
@client.event
async def on_message(message)
    # /test と打った場合のみ反応するように
    if message.content != '/test':
        return
    # message インスタンスから guild インスタンスを取得
    guild = message.guild 
    # ユーザとBOTを区別しない場合
    member_count = guild.member_count
    await message.channel.send(f'メンバー数：{member_count}')
    # ユーザのみ
    user_count = sum(1 for member in guild.members if not member.bot)
    await message.channel.send(f'ユーザ数：{user_count}')
    # BOTのみ
    bot_count = sum(1 for member in guild.memers if member.bot)
    await message.channel.send(f'BOT数：{bot_count}')
```

# ドキュメント

- [discord.Guild.member_count | discord.py](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.member_count)
- [discord.Guild.members | discord.py](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.members)
- [Pythonリスト内包表記の使い方 | note.nkmk.me](https://note.nkmk.me/python-list-comprehension/)