### PR TITLE
記事追加：message.channelがTextChannel以外なら無視する【discord.py】

### DIFF
--- a/content/blog/4.md
+++ b/content/blog/4.md
@@ -1,0 +1,26 @@
+---
+author: "1ntegrale9"
+categories: ["discord.py", "Message", "TextChannel"]
+date: 2019-12-26T20:08:59+09:00
+title: "message.channelがTextChannel以外なら無視する【discord.py】"
+type: "post"
+draft: false
+
+---
+
+# ソースコード
+
+`message.channel` が `discord.TextChannel` のインスタンスかどうかで分岐するようにします。
+
+```python
+@client.event
+async def on_message(message):
+    if not isinstance(message.channel, discord.TextChannel):
+        return
+    await message.channel.send('ここはTextChannelだよ')
+```
+
+# 参考ドキュメント
+
+- [Pythonで型を取得・判定するtype関数, isinstance関数 | note.nkmk.me](https://note.nkmk.me/python-type-isinstance/)
+- [discord.Message.channel  discord.py 1.2.3 documentation](https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.channel)


### PR DESCRIPTION
# ソースコード

`message.channel` が `discord.TextChannel` のインスタンスかどうかで分岐するようにします。

```python
@client.event
async def on_message(message):
    if not isinstance(message.channel, discord.TextChannel):
        return
    await message.channel.send('ここはTextChannelだよ')
```

# 参考ドキュメント

- [Pythonで型を取得・判定するtype関数, isinstance関数 | note.nkmk.me](https://note.nkmk.me/python-type-isinstance/)
- [discord.Message.channel  discord.py 1.2.3 documentation](https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.channel)