### PR TITLE
記事追加：リアクションを付けた人に役職を付与する【discord.py】

### DIFF
--- a/content/blog/5.md
+++ b/content/blog/5.md
@@ -14,26 +14,32 @@ draft: false
 # ソースコード
 
 ```python
-import discord
-import os
-
-client = discord.Client()
-token = os.environ['DISCORD_BOT_TOKEN']
-
-ID_CHANNEL_README = 0 # 該当のチャンネルのID
-ID_ROLE_WELCOME = 0 # 付けたい役職のID
+ID_CHANNEL_README = 729000364261967998 # 該当のチャンネルのID
+ID_ROLE_WELCOME = 775643766212653538 # 付けたい役職のID
 
 @client.event
 async def on_raw_reaction_add(payload):
+    # channel_id から Channel オブジェクトを取得
     channel = client.get_channel(payload.channel_id)
-    if channel.id == ID_CHANNEL_README:
-        guild = client.get_guild(payload.guild_id)
-        member = guild.get_member(payload.user_id)
-        role = guild.get_role(ID_ROLE_WELCOME)
-        await member.add_roles(role)
-        await channel.send('いらっしゃいませ！')
 
-client.run(token)
+    # 該当のチャンネル以外はスルー
+    if channel.id != ID_CHANNEL_README:
+        return
+
+    # guild_id から Guild オブジェクトを取得
+    guild = client.get_guild(payload.guild_id)
+
+    # user_id から Member オブジェクトを取得
+    member = guild.get_member(payload.user_id)
+
+    # 用意した役職IDから Role オブジェクトを取得
+    role = guild.get_role(ID_ROLE_WELCOME)
+
+    # リアクションを付けたメンバーに役職を付与
+    await member.add_roles(role)
+
+    # 分かりやすいように歓迎のメッセージを送る
+    await channel.send('いらっしゃいませ！')
 ```
 
 固定のメッセージに対するリアクションであれば、  
@@ -41,8 +47,8 @@ client.run(token)
 
 https://discordpy.readthedocs.io/en/latest/api.html#discord.on_raw_reaction_add
 
-ただし、on_reaction_add はbotがログインする前のメッセージに付くリアクションを検知できません。
-また、引数の `payload` は少し特殊で、各 id が格納されているため、
+ただし、on_reaction_add はbotがログインする前のメッセージに付くリアクションを検知できません。  
+また、引数の `payload` は少し特殊で、各 id が格納されているため、  
 get や fetch といったメソッドを使って各オブジェクトを取得する必要があります。
 
 https://discordpy.readthedocs.io/en/latest/api.html#discord.RawReactionActionEvent

--- a/content/blog/5.md
+++ b/content/blog/5.md
@@ -1,0 +1,53 @@
+---
+author: "1ntegrale9"
+categories: ["discord.py", "Reaction"]
+date: 2019-12-26T20:20:52+09:00
+title: "リアクションを付けた人に役職を付与する【discord.py】"
+type: "post"
+draft: false
+
+---
+
+例えば、新規メンバーが利用規約を読んでリアクションを押さないと、  
+チャンネルを見ることができない、というような用途に使えます。
+
+# ソースコード
+
+```python
+import discord
+import os
+
+client = discord.Client()
+token = os.environ['DISCORD_BOT_TOKEN']
+
+ID_CHANNEL_README = 0 # 該当のチャンネルのID
+ID_ROLE_WELCOME = 0 # 付けたい役職のID
+
+@client.event
+async def on_raw_reaction_add(payload):
+    channel = client.get_channel(payload.channel_id)
+    if channel.id == ID_CHANNEL_README:
+        guild = client.get_guild(payload.guild_id)
+        member = guild.get_member(payload.user_id)
+        role = guild.get_role(ID_ROLE_WELCOME)
+        await member.add_roles(role)
+        await channel.send('いらっしゃいませ！')
+
+client.run(token)
+```
+
+固定のメッセージに対するリアクションであれば、  
+`on_reaction_add` ではなく `on_raw_reaction_add` を使います。
+
+https://discordpy.readthedocs.io/en/latest/api.html#discord.on_raw_reaction_add
+
+ただし、on_reaction_add はbotがログインする前のメッセージに付くリアクションを検知できません。
+また、引数の `payload` は少し特殊で、各 id が格納されているため、
+get や fetch といったメソッドを使って各オブジェクトを取得する必要があります。
+
+https://discordpy.readthedocs.io/en/latest/api.html#discord.RawReactionActionEvent
+
+コマンドを打つ -> botがメッセージを出す -> リアクションを見る  
+という流れであれば `on_reaction_add` を使う方がシンプルです。
+
+https://discordpy.readthedocs.io/en/latest/api.html#discord.on_reaction_add


### PR DESCRIPTION
例えば、新規メンバーが利用規約を読んでリアクションを押さないと、  
チャンネルを見ることができない、というような用途に使えます。

# ソースコード

```python
ID_CHANNEL_README = 729000364261967998 # 該当のチャンネルのID
ID_ROLE_WELCOME = 775643766212653538 # 付けたい役職のID

@client.event
async def on_raw_reaction_add(payload):
    # channel_id から Channel オブジェクトを取得
    channel = client.get_channel(payload.channel_id)

    # 該当のチャンネル以外はスルー
    if channel.id != ID_CHANNEL_README:
        return

    # guild_id から Guild オブジェクトを取得
    guild = client.get_guild(payload.guild_id)

    # user_id から Member オブジェクトを取得
    member = guild.get_member(payload.user_id)

    # 用意した役職IDから Role オブジェクトを取得
    role = guild.get_role(ID_ROLE_WELCOME)

    # リアクションを付けたメンバーに役職を付与
    await member.add_roles(role)

    # 分かりやすいように歓迎のメッセージを送る
    await channel.send('いらっしゃいませ！')
```

固定のメッセージに対するリアクションであれば、  
`on_reaction_add` ではなく `on_raw_reaction_add` を使います。

https://discordpy.readthedocs.io/en/latest/api.html#discord.on_raw_reaction_add

ただし、on_reaction_add はbotがログインする前のメッセージに付くリアクションを検知できません。  
また、引数の `payload` は少し特殊で、各 id が格納されているため、  
get や fetch といったメソッドを使って各オブジェクトを取得する必要があります。

https://discordpy.readthedocs.io/en/latest/api.html#discord.RawReactionActionEvent

コマンドを打つ -> botがメッセージを出す -> リアクションを見る  
という流れであれば `on_reaction_add` を使う方がシンプルです。

https://discordpy.readthedocs.io/en/latest/api.html#discord.on_reaction_add