### PR TITLE
記事追加：メンバーに一括で役職を付与【discord.py】

### DIFF
--- a/content/blog/7.md
+++ b/content/blog/7.md
@@ -1,6 +1,6 @@
 ---
 author: "1ntegrale9"
-categories: ["discord.py", "Reaction"]
+categories: ["discord.py", "Role", "ext"]
 date: 2019-12-26T23:20:57+09:00
 title: "メンバーに一括で役職を付与【discord.py】"
 type: "post"
@@ -8,27 +8,31 @@ draft: false
 
 ---
 
-Discordサーバーの管理のため、
-everyoneの権限を全てOFFにして、
-メンバー全員にmemberという基本権限のついた役職を付与するために、
-必要になったのでコマンドを作成。
-
 # 仕様
-`/set_members` というコマンドを打つと、
-bot以外の全てのメンバーに `member` 役職が付く。
-`member` 役職は作成済みとする。
-このコマンドは管理者権限持ちのみが実行できる。
+
+[discord.ext.commands](https://discordpy.readthedocs.io/ja/latest/ext/commands/) が前提です。
+
+`/set_members` というコマンドを打つと、  
+bot 以外の全てのメンバーに作成済みの `basic` 役職が付きます。
+
+このコマンドは管理者権限持ちのみが実行できます。
 
 # ソースコード
 
 ```python
-@client.event
+ROLE_BASIC_ID = 934598783292524930
+
+@bot.command()
 @commands.has_permissions(administrator=True)
 async def set_members(ctx):
+    role_basic = ctx.guild.get_role(ROLE_BASIC_ID)
     for member in ctx.guild.members:
         if not member.bot:
-            role = discord.utils.find(lambda r: r.name == 'member', ctx.guild.roles)
-            await member.add_roles(role)
-
-client.run(token)
+            await member.add_roles(role_basic)
 ```
+
+# 参考ドキュメント
+
+- [ctx.guild](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Context.guild)
+- [Guild.get_role](https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.get_role)
+- [commands.has_permissions](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.has_permissions)

--- a/content/blog/7.md
+++ b/content/blog/7.md
@@ -1,0 +1,34 @@
+---
+author: "1ntegrale9"
+categories: ["discord.py", "Reaction"]
+date: 2019-12-26T23:20:57+09:00
+title: "メンバーに一括で役職を付与【discord.py】"
+type: "post"
+draft: false
+
+---
+
+Discordサーバーの管理のため、
+everyoneの権限を全てOFFにして、
+メンバー全員にmemberという基本権限のついた役職を付与するために、
+必要になったのでコマンドを作成。
+
+# 仕様
+`/set_members` というコマンドを打つと、
+bot以外の全てのメンバーに `member` 役職が付く。
+`member` 役職は作成済みとする。
+このコマンドは管理者権限持ちのみが実行できる。
+
+# ソースコード
+
+```python
+@client.event
+@commands.has_permissions(administrator=True)
+async def set_members(ctx):
+    for member in ctx.guild.members:
+        if not member.bot:
+            role = discord.utils.find(lambda r: r.name == 'member', ctx.guild.roles)
+            await member.add_roles(role)
+
+client.run(token)
+```


### PR DESCRIPTION
# 仕様

[discord.ext.commands](https://discordpy.readthedocs.io/ja/latest/ext/commands/) が前提です。

`/set_members` というコマンドを打つと、  
bot 以外の全てのメンバーに作成済みの `basic` 役職が付きます。

このコマンドは管理者権限持ちのみが実行できます。

# ソースコード

```python
ROLE_BASIC_ID = 934598783292524930

@bot.command()
@commands.has_permissions(administrator=True)
async def set_members(ctx):
    role_basic = ctx.guild.get_role(ROLE_BASIC_ID)
    for member in ctx.guild.members:
        if not member.bot:
            await member.add_roles(role_basic)
```

# 参考ドキュメント

- [ctx.guild](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Context.guild)
- [Guild.get_role](https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.get_role)
- [commands.has_permissions](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.has_permissions)