### PR TITLE
記事追加: DMにさまざまな種類のメッセージを送信する【discord.py】

### DIFF
--- a/content/blog/11.md
+++ b/content/blog/11.md
@@ -1,0 +1,60 @@
+---
+title: DMにさまざまな種類のメッセージを送信する【discord.py】
+date: 2021-03-24T13:35:40.720Z
+categories:
+  - discord.py
+  - Message
+type: post
+draft: false
+---
+
+ユーザーのDMにさまざまな種類のメッセージを送信する方法です。
+
+[discord.User.send](https://discordpy.readthedocs.io/ja/latest/api.html?highlight=message#discord.User.send)
+
+## サンプルコード
+
+以下は各コマンドを打った時に、
+コマンドを打った人のDMに各種メッセージを送信するコードです。
+
+```python
+import discord 
+
+@client.event
+async def on_message(message):
+
+    #メッセージを送信する
+    if message.content.startswith('/send_dm'):
+
+        # DMに送るメッセージを取得
+        msg = message.content.replace('/send_dm ', '')
+
+        # コマンドを打った人のDMに送信
+        await message.author.send(msg)
+        # message.author はメッセージを送信したユーザーです
+    
+    # Embedメッセージを送信する
+    elif message.content.startswith('/send_embed'):
+
+        # Embedメッセージ
+        embed_msg = discord.Embed(title="Embedメッセージ", description="正常に送信されました")
+
+        # コマンドを打った人のDMに送信
+        await message.author.send(embed=embed_msg)
+    
+    # ファイルを送信する
+    elif message.content.startswith('/send_file'):
+        
+        # コマンドを打った人のDMに送信
+        await message.author.send(content='ファイル送信', file=discord.File('test.txt'))
+        # discord.File()には、送信したいファイルの名前やファイルパスを入れます。
+        # 例) 'image.jpg', './image/1.png', 'data.txt' など
+
+
+```
+
+## 参考リンク
+ - [discord.User.send](https://discordpy.readthedocs.io/ja/latest/api.html?highlight=message#discord.User.send)
+ - [discord.abc.Messageable.send](https://discordpy.readthedocs.io/ja/latest/api.html#discord.abc.Messageable.send)
+ - [discord.File](https://discordpy.readthedocs.io/en/latest/api.html#discord.File)
+ - [discord.Embed](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed)

--- a/content/blog/11.md
+++ b/content/blog/11.md
@@ -24,7 +24,7 @@ import discord
 async def on_message(message):
 
     #メッセージを送信する
-    if message.content.startswith('/send_dm'):
+    if message.content.startswith('/send_dm '):
 
         # DMに送るメッセージを取得
         msg = message.content.replace('/send_dm ', '')


### PR DESCRIPTION
参考チャンネル
・580625036763725827 (メッセージ送信)
・603505848609931265 (ファイル送信)
・591598413007814656 (Embed送信, Commandが使われている)