### PR TITLE
Fix: 1.mdのカテゴリ名の統一化

### DIFF
--- a/content/blog/1.md
+++ b/content/blog/1.md
@@ -1,6 +1,6 @@
 ---
 author: "1ntegrale9"
-categories: ["discord.py", "役職"]
+categories: ["discord.py", "Role"]
 date: 2019-11-01T11:35:49+09:00
 title: "特定の名前の役職(Role)を消す【discord.py】"
 type: "post"


### PR DESCRIPTION
Roleに関する記事なのですが、他2つの記事のカテゴリ名は`Role` となっていたため統一したほうが良いかなと思いPR出しました。