### PR TITLE
Fix: 6.mdのカテゴリー名の変更

### DIFF
--- a/content/blog/6.md
+++ b/content/blog/6.md
@@ -30,6 +30,6 @@ async def on_member_join(member):
 
 # 参考ドキュメント
 
- - [discord.on_member_join](https://discordpy.readthedocs.io/ja/latest/api.html#discord.on_member_join)
- - [discord.Guild.get_role](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.get_role)
- - [discord.Member.add_roles](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Member.add_roles)
+- [discord.on_member_join](https://discordpy.readthedocs.io/ja/latest/api.html#discord.on_member_join)
+- [discord.Guild.get_role](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.get_role)
+- [discord.Member.add_roles](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Member.add_roles)

--- a/content/blog/6.md
+++ b/content/blog/6.md
@@ -1,6 +1,6 @@
 ---
 author: "1ntegrale9"
-categories: ["discord.py", "Reaction"]
+categories: ["discord.py", "Role"]
 date: 2019-12-26T23:18:28+09:00
 title: "サーバーに参加した人に自動で役職を付与する【discord.py】"
 type: "post"
@@ -30,6 +30,6 @@ async def on_member_join(member):
 
 # 参考ドキュメント
 
-https://discordpy.readthedocs.io/en/latest/api.html#discord.on_member_join
-https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.get_role
-https://discordpy.readthedocs.io/en/latest/api.html#discord.Member.add_roles
+ - [discord.on_member_join](https://discordpy.readthedocs.io/ja/latest/api.html#discord.on_member_join)
+ - [discord.Guild.get_role](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Guild.get_role)
+ - [discord.Member.add_roles](https://discordpy.readthedocs.io/ja/latest/api.html#discord.Member.add_roles)


### PR DESCRIPTION
役職関係の記事なのに、カテゴリー名に `Reaction` があったため `Role` に変更しました
また、参考ドキュメントの部分の書き方をMarkdown形式に変更しました