### PR TITLE
Fix: 検索が記事内検索になっていなかったのでその修正

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "/"
+baseurl = "https://discordbot.jp/"
 languageCode = "ja-jp"
 title = "Discord Bot Portal JP"
 theme = "hugo-future-imperfect"


### PR DESCRIPTION
自分の環境で試してみたところ、
urlを入れない => 普通のGoogle検索
urlを入れる => サイト内検索
になりましたので、できるかまだ確証はありませんがPR出しました